### PR TITLE
unnecessary gradle import for android

### DIFF
--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -19,7 +19,6 @@ dependencies {
     compile "com.android.support:recyclerview-v7:$suppotVer"
     compile "com.android.support:percent:$suppotVer"
 
-    compile 'com.facebook.fresco:fresco:0.14.1'
     compile 'com.neovisionaries:nv-websocket-client:1.30'
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
 


### PR DESCRIPTION
The package does not need fresco as a dependency to work. 
Also having it there breaks other NativeScript applications who have already Fresco installed by causing a package clash.

@dennis-montana  can you confirm?